### PR TITLE
travis will only deploy to testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,7 +47,7 @@ deploy:
   skip_cleanup: true
   on: &2
     repo: kcoyner/ERS-Dispatch-Listening-Server
-    all_branches: true
+    branch: testing
   bucket: ers-dispatch
   upload-dir: testing
   region: us-east-1


### PR DESCRIPTION
This revision changes travis so that it only deploys to the testing
server when you push to your personal testing branch. You can now push
to other branches without having them automatically deployed every time.